### PR TITLE
Auto refresh the events when hitting map view

### DIFF
--- a/WhatsHappenin/Events/CreateEvent.swift
+++ b/WhatsHappenin/Events/CreateEvent.swift
@@ -60,7 +60,9 @@ struct CreateEvent : View {
                 TextField("Zipcode", text: $zipcode)
             }
             Button(action: {
-                            self.showAlert = true
+                self.showAlert = true
+//                cntlr.events.append(Event) This is the idea
+                
                         }, label: { Text("Submit" )})
             .alert(isPresented: $showAlert) {
                         Alert(

--- a/WhatsHappenin/Events/ShowMap.swift
+++ b/WhatsHappenin/Events/ShowMap.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ShowMap: View {
     @StateObject private var viewModel = ShowMapModel()
-    
+
     var body: some View {
         Map(coordinateRegion: $viewModel.region, showsUserLocation: true,
                     annotationItems: cntlr.events){ event in
@@ -24,6 +24,8 @@ struct ShowMap: View {
         //            .accentColor(Color(.systemPink)) // change current location circle to pink ^_^
                     .onAppear {
                         viewModel.checkIfLocationServicesIsEnabled()
+                        viewModel.reload()
+                            
                     }
     }
 //
@@ -44,6 +46,8 @@ final class ShowMapModel: NSObject, ObservableObject, CLLocationManagerDelegate 
                                                    span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01))
     
     var locationManager: CLLocationManager?
+    
+    @State var isRefreshing: Bool = false
     
     func checkIfLocationServicesIsEnabled() {
         if CLLocationManager.locationServicesEnabled() {
@@ -80,6 +84,14 @@ final class ShowMapModel: NSObject, ObservableObject, CLLocationManagerDelegate 
     // Check if user turned off location services while the app is open
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         checkLocationAuthorization()
+    }
+    
+    func reload() {
+        print("Reloading Map")
+        cntlr.reloadNearbyEvents()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            self.isRefreshing = false
+        }
     }
 }
 


### PR DESCRIPTION
Fixed my end of [Issue #14 ](https://github.com/CWRUSeniorProject2021/whats-happenin-ios/issues/14). Now events will auto reload when opening maps page